### PR TITLE
Add fix for installing snowflake-connector-python

### DIFF
--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -127,8 +127,25 @@ class HomebrewTemplate:
 
             {dependencies}
               def install
-                virtualenv_install_with_resources using: "python3"
-                bin.install_symlink "#{{libexec}}/bin/dbt" => "dbt"
+                venv = virtualenv_create(libexec, "python3")
+
+                resources.each do |r|
+                  # workaround for install snowflake-connector-python 
+                  # package w/o build-system deps (e.g. pyarrow)
+                  if r.name == "snowflake-connector-python"
+                    r.stage {
+                    venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
+                        "-v", "--no-deps", "--no-binary", ":all:",
+                        "--ignore-installed", "--no-use-pep517", Pathname.pwd
+                    }
+                  else
+                    venv.pip_install r
+                  end
+                end
+                
+                venv.pip_install_and_link buildpath
+
+                bin.install_symlink "#{libexec}/bin/dbt" => "dbt"
               end
 
               test do


### PR DESCRIPTION
This is a workaround for installing snowflake connector python for dbt with Homebrew.

### Issue 🐞 
SCP installs build-system dependencies [PEP 517](https://www.python.org/dev/peps/pep-0517/) listed [here](https://github.com/snowflakedb/snowflake-connector-python/blob/master/pyproject.toml) for versions >= 2.3.0. Homebrew tries to install the build dependencies from source, which fails to install. This can be recreated by running `pip install -v --no-deps --no-binary :all: --ignore-installed snowflake-connector-python==2.3.6`
```
pip._internal.exceptions.InstallationError:
Command errored out with exit status 1: /usr/local/Cellar/dbt/0.19.0b1_1/libexec/bin/python
/usr/local/Cellar/dbt/0.19.0b1_1/libexec/lib/python3.8/site-packages/pip install --ignore-installed --no-user --prefix
/private/tmp/pip-build-env-l_k1ll5r/overlay --no-warn-script-location -v --no-binary :all: --only-binary :none: -i
https://pypi.org/simple -- 'setuptools>=40.6.0' wheel cython 'pyarrow>=0.17.0,<0.18.0' Check the logs for full command
output.
```
### Workaround 🔨 
This workaround installs python dependencies as normal **_except_** snowflake-connector-python. For snowflake-connector-python, this will use the same command to install the package as well as pass the `--no-use-pep517` flag. This will install the package without installing the build system dependencies as defined (see https://github.com/snowflakedb/snowflake-connector-python/pull/355). I believe this will only affect using snowflake-connection-python with pandas. I tested this Homebrew formula locally with success 👍 

### Follow up ✏️ 
This is a one-off hack for installing `snowflake-connector-python`.  I know homebrew prefers to install dependencies from source, but maybe we can make an exception for snowflake-connector-python. I'm open to other ideas and will create an issue to follow up with this workaround.