### PR TITLE
Remove one off fixes for installing snowflake-connector-python

### DIFF
--- a/scripts/release-pypath/builder/homebrew.py
+++ b/scripts/release-pypath/builder/homebrew.py
@@ -131,24 +131,7 @@ class HomebrewTemplate:
 
             {dependencies}
               def install
-                venv = virtualenv_create(libexec, "python3")
-
-                resources.each do |r|
-                  # workaround for install snowflake-connector-python
-                  # package w/o build-system deps (e.g. pyarrow)
-                  if r.name == "snowflake-connector-python"
-                    r.stage {{
-                      venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
-                        "-v", "--no-deps", "--no-binary", ":all:",
-                        "--ignore-installed", "--no-use-pep517", Pathname.pwd
-                    }}
-                  else
-                    venv.pip_install r
-                  end
-                end
-
-                venv.pip_install_and_link buildpath
-
+                virtualenv_install_with_resources using: "python3"
                 bin.install_symlink "#{{libexec}}/bin/dbt" => "dbt"
               end
 


### PR DESCRIPTION
### Description

I think it makes sense to manually apply fixes for installing SCP and other deps instead of baking it into the release process. I'm hopeful that newer versions will not need custom code in Homebrew formula to be able to install!